### PR TITLE
Add include guards

### DIFF
--- a/src/lib.bats
+++ b/src/lib.bats
@@ -14,6 +14,8 @@
 
 $UNSAFE begin
 %{#
+#ifndef _BRIDGE_RUNTIME_DEFINED
+#define _BRIDGE_RUNTIME_DEFINED
 /* Bridge int stash -- 4 slots for stash IDs and metadata */
 static int _bridge_stash_int[4] = {0};
 
@@ -51,6 +53,7 @@ void *bats_listener_get(int id) {
 
 /* JS-side data stash read import */
 static void _bridge_stash_read(int stash_id, void *dest, int len);
+#endif
 %}
 end
 


### PR DESCRIPTION
## Summary
- Add `#ifndef _BRIDGE_RUNTIME_DEFINED` / `#define` / `#endif` include guards around the C runtime block in `src/lib.bats`
- Prevents duplicate definition errors when multiple packages are linked together

## Test plan
- [x] `bats check` passes locally

Generated with [Claude Code](https://claude.com/claude-code)