### PR TITLE
Wrap all unsafe constructs in outer $UNSAFE blocks

### DIFF
--- a/src/blob.bats
+++ b/src/blob.bats
@@ -32,6 +32,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_create_blob_url
   (data: ptr, data_len: int, mime: ptr, mime_len: int): int
@@ -44,21 +45,22 @@ extern fun _bats_js_download_blob
 
 implement create_blob_url{ld}{nd}{lm}{nm}(data, data_len, mime, mime_len) =
   _bats_js_create_blob_url(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(data) end, data_len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(mime) end, mime_len)
+    $UNSAFE.castvwtp1{ptr}(data), data_len,
+    $UNSAFE.castvwtp1{ptr}(mime), mime_len)
 
 implement create_blob_url_get{n}(len) =
   stash_read(stash_get_int(1), len)
 
 implement revoke_blob_url{lb}{n}(url, url_len) =
   _bats_js_revoke_blob_url(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end, url_len)
+    $UNSAFE.castvwtp1{ptr}(url), url_len)
 
 implement download_blob{ld}{nd}{lm}{nm}{ln}{nn}
   (data, data_len, mime, mime_len, name, name_len) =
   _bats_js_download_blob(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(data) end, data_len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(mime) end, mime_len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(name) end, name_len)
+    $UNSAFE.castvwtp1{ptr}(data), data_len,
+    $UNSAFE.castvwtp1{ptr}(mime), mime_len,
+    $UNSAFE.castvwtp1{ptr}(name), name_len)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/clipboard.bats
+++ b/src/clipboard.bats
@@ -32,6 +32,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_clipboard_write_text
   (text: ptr, text_len: int, resolver_id: int)
@@ -43,7 +44,7 @@ implement clipboard_write{lb}{n}(text, text_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_clipboard_write_text(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(text) end, text_len,
+    $UNSAFE.castvwtp1{ptr}(text), text_len,
     id)
 in p end
 
@@ -62,4 +63,5 @@ implement on_clipboard_complete(resolver_id, success) =
 implement on_clipboard_read_complete(resolver_id, text_len) =
   $P.fire(resolver_id, text_len)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/decompress.bats
+++ b/src/decompress.bats
@@ -34,6 +34,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_decompress
   (data: ptr, data_len: int, method: int, resolver_id: int)
@@ -47,7 +48,7 @@ implement decompress{lb}{n}(data, data_len, method) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_decompress(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(data) end,
+    $UNSAFE.castvwtp1{ptr}(data),
     data_len, method, id)
 in p end
 
@@ -55,7 +56,7 @@ implement decompress_len() = stash_get_int(0)
 
 implement blob_read{l}{n}(handle, blob_offset, out, len) = let
   val r = _bats_js_blob_read(handle, blob_offset, len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end)
+    $UNSAFE.castvwtp1{ptr}(out))
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
 end
@@ -66,4 +67,5 @@ implement on_decompress_complete(resolver_id, handle, decompressed_len) = let
   val () = stash_set_int(0, decompressed_len)
 in $P.fire(resolver_id, handle) end
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/dom.bats
+++ b/src/dom.bats
@@ -25,6 +25,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_dom_flush
   (buf: ptr, len: int): void = "mac#bats_dom_flush"
@@ -34,18 +35,19 @@ extern fun _bats_js_set_image_src
 
 implement dom_flush{l}{n}{m}(buf, len) =
   _bats_dom_flush(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(buf) end,
+    $UNSAFE.castvwtp1{ptr}(buf),
     len)
 
 implement set_image_src{ld}{nd}{lm}{nm}
   (node_id, data, data_len, mime, mime_len) =
   _bats_js_set_image_src(node_id,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(data) end, data_len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(mime) end, mime_len)
+    $UNSAFE.castvwtp1{ptr}(data), data_len,
+    $UNSAFE.castvwtp1{ptr}(mime), mime_len)
 
 extern fun _bats_js_click_node
   (node_id: int): void = "mac#bats_js_click_node"
 
 implement click_node(node_id) = _bats_js_click_node(node_id)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/dom_read.bats
+++ b/src/dom_read.bats
@@ -60,6 +60,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_measure_node
   (node_id: int): int = "mac#bats_js_measure_node"
@@ -93,7 +94,7 @@ implement get_measure_scroll_h() = $extfcall(int, "bats_bridge_measure_get", 5)
 
 implement query_selector{lb}{n}(sel, sel_len) = let
   val r = _bats_js_query_selector(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(sel) end,
+    $UNSAFE.castvwtp1{ptr}(sel),
     sel_len)
 in
   if r >= 0 then $R.some(r) else $R.none()
@@ -129,4 +130,5 @@ extern fun _bats_js_read_input_value
 implement read_input_value(node_id, max_len) =
   _bats_js_read_input_value(node_id, the_null_ptr, max_len)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/event.bats
+++ b/src/event.bats
@@ -38,6 +38,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_add_event_listener
   (node_id: int, event_type: ptr, type_len: int, listener_id: int)
@@ -52,18 +53,18 @@ extern fun _bats_js_prevent_default
 
 implement listen{lb}{n}
   (node_id, event_type, type_len, listener_id, callback) = let
-  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(callback) end
+  val cbp = $UNSAFE.castvwtp0{ptr}(callback)
   val () = $extfcall(void, "bats_listener_set", listener_id, cbp)
 in _bats_js_add_event_listener(node_id,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(event_type) end,
+    $UNSAFE.castvwtp1{ptr}(event_type),
     type_len, listener_id) end
 
 implement listen_document{lb}{n}
   (event_type, type_len, listener_id, callback) = let
-  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(callback) end
+  val cbp = $UNSAFE.castvwtp0{ptr}(callback)
   val () = $extfcall(void, "bats_listener_set", listener_id, cbp)
 in _bats_js_add_document_listener(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(event_type) end,
+    $UNSAFE.castvwtp1{ptr}(event_type),
     type_len, listener_id) end
 
 implement unlisten(listener_id) = let
@@ -80,10 +81,11 @@ implement on_event(listener_id, payload_len) = let
   val cbp = $extfcall(ptr, "bats_listener_get", listener_id)
 in
   if ptr_isnot_null(cbp) then let
-    val cb = $UNSAFE begin $UNSAFE.cast{(int) -<cloref1> int}(cbp) end
+    val cb = $UNSAFE.cast{(int) -<cloref1> int}(cbp)
     val _ = cb(payload_len)
   in () end
   else ()
 end
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/fetch.bats
+++ b/src/fetch.bats
@@ -29,6 +29,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_fetch
   (url: ptr, url_len: int, resolver_id: int): void = "mac#bats_js_fetch"
@@ -37,7 +38,7 @@ implement fetch{lb}{n}(url, url_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_fetch(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end, url_len,
+    $UNSAFE.castvwtp1{ptr}(url), url_len,
     id)
 in p end
 
@@ -51,4 +52,5 @@ implement on_fetch_complete(resolver_id, status, body_len) = let
   val () = stash_set_int(0, body_len)
 in $P.fire(resolver_id, status) end
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/file.bats
+++ b/src/file.bats
@@ -38,6 +38,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_file_open
   (input_node_id: int, resolver_id: int): void = "mac#bats_js_file_open"
@@ -61,7 +62,7 @@ implement file_name{n}(len) =
 
 implement file_read{l}{n}(handle, file_offset, out, len) = let
   val r = _bats_js_file_read(handle, file_offset, len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end)
+    $UNSAFE.castvwtp1{ptr}(out))
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
 end
@@ -72,4 +73,5 @@ implement on_file_open(resolver_id, handle, size) = let
   val () = stash_set_int(0, size)
 in $P.fire(resolver_id, handle) end
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/idb.bats
+++ b/src/idb.bats
@@ -51,6 +51,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_idb_js_put
   (key: ptr, key_len: int, val_data: ptr, val_len: int, resolver_id: int)
@@ -69,8 +70,8 @@ implement idb_put{lk}{nk}{lv}{nv}(key, key_len, val_data, val_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_put(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(key) end, key_len,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(val_data) end, val_len,
+    $UNSAFE.castvwtp1{ptr}(key), key_len,
+    $UNSAFE.castvwtp1{ptr}(val_data), val_len,
     id)
 in p end
 
@@ -78,7 +79,7 @@ implement idb_get{lk}{nk}(key, key_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_get(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(key) end, key_len,
+    $UNSAFE.castvwtp1{ptr}(key), key_len,
     id)
 in p end
 
@@ -89,7 +90,7 @@ implement idb_delete{lk}{nk}(key, key_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_delete(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(key) end, key_len,
+    $UNSAFE.castvwtp1{ptr}(key), key_len,
     id)
 in p end
 
@@ -97,7 +98,7 @@ implement idb_list_keys{lb}{n}(prefix, prefix_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_list_keys(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(prefix) end, prefix_len,
+    $UNSAFE.castvwtp1{ptr}(prefix), prefix_len,
     id)
 in p end
 
@@ -115,4 +116,5 @@ extern fun _bats_js_idb_delete_database
 
 implement idb_delete_database() = _bats_js_idb_delete_database()
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/media.bats
+++ b/src/media.bats
@@ -25,6 +25,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_match_media
   (query: ptr, query_len: int): int = "mac#bats_js_match_media"
@@ -34,23 +35,24 @@ extern fun _bats_js_listen_media
 
 implement match_media{lb}{n}(query, query_len) =
   _bats_js_match_media(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(query) end, query_len)
+    $UNSAFE.castvwtp1{ptr}(query), query_len)
 
 implement listen_media{lb}{n}(query, query_len, listener_id, callback) = let
-  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(callback) end
+  val cbp = $UNSAFE.castvwtp0{ptr}(callback)
   val () = $extfcall(void, "bats_listener_set", listener_id, cbp)
 in _bats_js_listen_media(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(query) end, query_len,
+    $UNSAFE.castvwtp1{ptr}(query), query_len,
     listener_id) end
 
 implement on_media_change(listener_id, matches) = let
   val cbp = $extfcall(ptr, "bats_listener_get", listener_id)
 in
   if ptr_isnot_null(cbp) then let
-    val cb = $UNSAFE begin $UNSAFE.cast{(int) -<cloref1> int}(cbp) end
+    val cb = $UNSAFE.cast{(int) -<cloref1> int}(cbp)
     val _ = cb(matches)
   in () end
   else ()
 end
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/nav.bats
+++ b/src/nav.bats
@@ -42,6 +42,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_get_url
   (out: ptr, max_len: int): int = "mac#bats_js_get_url"
@@ -56,7 +57,7 @@ extern fun _bats_js_push_state
 
 implement get_url{l}{n}(out, max_len) = let
   val r = _bats_js_get_url(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end,
+    $UNSAFE.castvwtp1{ptr}(out),
     max_len)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
@@ -64,7 +65,7 @@ end
 
 implement get_hash{l}{n}(out, max_len) = let
   val r = _bats_js_get_url_hash(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end,
+    $UNSAFE.castvwtp1{ptr}(out),
     max_len)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
@@ -72,17 +73,17 @@ end
 
 implement set_hash{lb}{n}(hash, hash_len) =
   _bats_js_set_url_hash(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(hash) end,
+    $UNSAFE.castvwtp1{ptr}(hash),
     hash_len)
 
 implement replace_state{lb}{n}(url, url_len) =
   _bats_js_replace_state(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end,
+    $UNSAFE.castvwtp1{ptr}(url),
     url_len)
 
 implement push_state{lb}{n}(url, url_len) =
   _bats_js_push_state(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end,
+    $UNSAFE.castvwtp1{ptr}(url),
     url_len)
 
 extern fun _bats_js_reload
@@ -91,17 +92,18 @@ extern fun _bats_js_reload
 implement reload() = _bats_js_reload()
 
 implement set_popstate_callback(cb) = let
-  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(cb) end
+  val cbp = $UNSAFE.castvwtp0{ptr}(cb)
 in $extfcall(void, "bats_listener_set", 999999, cbp) end
 
 implement on_popstate(url_len) = let
   val cbp = $extfcall(ptr, "bats_listener_get", 999999)
 in
   if ptr_isnot_null(cbp) then let
-    val cb = $UNSAFE begin $UNSAFE.cast{(int) -<cloref1> int}(cbp) end
+    val cb = $UNSAFE.cast{(int) -<cloref1> int}(cbp)
     val _ = cb(url_len)
   in () end
   else ()
 end
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/notify.bats
+++ b/src/notify.bats
@@ -39,6 +39,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_notification_request_permission
   (resolver_id: int): void = "mac#bats_js_notification_request_permission"
@@ -58,14 +59,14 @@ in p end
 
 implement notify_show{lb}{n}(title, title_len) =
   _bats_js_notification_show(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(title) end,
+    $UNSAFE.castvwtp1{ptr}(title),
     title_len)
 
 implement notify_push_subscribe{lb}{n}(vapid, vapid_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_push_subscribe(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(vapid) end,
+    $UNSAFE.castvwtp1{ptr}(vapid),
     vapid_len, id)
 in p end
 
@@ -84,4 +85,5 @@ implement on_permission_result(resolver_id, granted) =
 implement on_push_subscribe(resolver_id, json_len) =
   $P.fire(resolver_id, json_len)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/scroll.bats
+++ b/src/scroll.bats
@@ -23,6 +23,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_scroll_to
   (node_id: int, x: int, y: int): void = "mac#bats_js_scroll_to"
@@ -45,4 +46,5 @@ implement set_scroll_top(node_id, value) =
 implement set_scroll_left(node_id, value) =
   _bats_js_set_scroll_left(node_id, value)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/stash.bats
+++ b/src/stash.bats
@@ -23,6 +23,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_stash_read
   (stash_id: int, dest: ptr, len: int): void = "mac#bats_js_stash_read"
@@ -30,7 +31,7 @@ extern fun _bats_js_stash_read
 fun _bridge_recv{n:pos | n <= 1048576}
   (stash_id: int, len: int n): [l:agz] $A.arr(byte, l, n) = let
   val buf = $A.alloc<byte>(len)
-  val p = $UNSAFE begin $UNSAFE.castvwtp1{ptr}(buf) end
+  val p = $UNSAFE.castvwtp1{ptr}(buf)
   val () = _bats_js_stash_read(stash_id, p, len)
 in buf end
 
@@ -47,4 +48,5 @@ implement stash_set_int(slot, v0) = _stash_set_int(slot, v0)
 
 implement stash_get_int(slot) = _stash_get_int(slot)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/timer.bats
+++ b/src/timer.bats
@@ -23,6 +23,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_set_timer
   (delay_ms: int, resolver_id: int): void = "mac#bats_set_timer"
@@ -44,4 +45,5 @@ implement exit() = _bats_exit()
 implement on_timer_fire(resolver_id) =
   $P.fire(resolver_id, 0)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/window.bats
+++ b/src/window.bats
@@ -21,6 +21,7 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_focus_window
   (): void = "mac#bats_js_focus_window"
@@ -35,7 +36,8 @@ implement get_visibility() = _bats_js_get_visibility_state()
 
 implement log{lb}{n}(level, msg, msg_len) =
   _bats_js_log(level,
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(msg) end,
+    $UNSAFE.castvwtp1{ptr}(msg),
     msg_len)
 
+end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/xml.bats
+++ b/src/xml.bats
@@ -21,16 +21,18 @@
    ============================================================ *)
 
 #target wasm begin
+$UNSAFE begin
 
 extern fun _bats_js_parse_html
   (html: ptr, len: int): int = "mac#bats_js_parse_html"
 
 implement xml_parse{lb}{n}(html, len) =
   _bats_js_parse_html(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(html) end,
+    $UNSAFE.castvwtp1{ptr}(html),
     len)
 
 implement xml_result{n}(len) =
   stash_read(stash_get_int(1), len)
 
+end (* $UNSAFE *)
 end (* #target wasm *)


### PR DESCRIPTION
## Summary

- Added `$UNSAFE begin...end` blocks wrapping all content inside `#target wasm begin...end` in 17 bridge module files
- Replaced inline `$UNSAFE begin X end` patterns with bare `X` expressions since they are now inside the outer `$UNSAFE` block
- Files modified: blob, clipboard, decompress, dom, dom_read, event, fetch, file, idb, media, nav, notify, scroll, stash, timer, window, xml

## Test plan

- [x] `bats lock --repository ../repository-prototype` succeeds
- [x] `bats check --repository ../repository-prototype` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)