### PR TITLE
Narrow $UNSAFE blocks in shared modules

### DIFF
--- a/src/clipboard.bats
+++ b/src/clipboard.bats
@@ -33,18 +33,18 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_clipboard_write_text
   (text: ptr, text_len: int, resolver_id: int)
   : void = "mac#bats_js_clipboard_write_text"
 extern fun _bats_js_clipboard_read_text
   (resolver_id: int): void = "mac#bats_js_clipboard_read_text"
+end
 
 implement clipboard_write{lb}{n}(text, text_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_clipboard_write_text(
-    $UNSAFE.castvwtp1{ptr}(text), text_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(text) end, text_len,
     id)
 in p end
 
@@ -63,5 +63,4 @@ implement on_clipboard_complete(resolver_id, success) =
 implement on_clipboard_read_complete(resolver_id, text_len) =
   $P.fire(resolver_id, text_len)
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/decompress.bats
+++ b/src/decompress.bats
@@ -35,7 +35,6 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_decompress
   (data: ptr, data_len: int, method: int, resolver_id: int)
   : void = "mac#bats_js_decompress"
@@ -43,12 +42,13 @@ extern fun _bats_js_blob_read
   (handle: int, blob_offset: int, len: int, out: ptr): int = "mac#bats_js_blob_read"
 extern fun _bats_js_blob_free
   (handle: int): void = "mac#bats_js_blob_free"
+end
 
 implement decompress{lb}{n}(data, data_len, method) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_decompress(
-    $UNSAFE.castvwtp1{ptr}(data),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(data) end,
     data_len, method, id)
 in p end
 
@@ -56,7 +56,7 @@ implement decompress_len() = stash_get_int(0)
 
 implement blob_read{l}{n}(handle, blob_offset, out, len) = let
   val r = _bats_js_blob_read(handle, blob_offset, len,
-    $UNSAFE.castvwtp1{ptr}(out))
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
 end
@@ -67,5 +67,4 @@ implement on_decompress_complete(resolver_id, handle, decompressed_len) = let
   val () = stash_set_int(0, decompressed_len)
 in $P.fire(resolver_id, handle) end
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/dom_read.bats
+++ b/src/dom_read.bats
@@ -67,7 +67,6 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_measure_node
   (id: ptr, id_len: int): int = "mac#bats_js_measure_node"
 extern fun _bats_js_query_selector
@@ -84,24 +83,27 @@ extern fun _bats_js_get_selection_rect
   (): void = "mac#bats_js_get_selection_rect"
 extern fun _bats_js_get_selection_range
   (): void = "mac#bats_js_get_selection_range"
+extern fun _bats_js_read_input_value
+  (id: ptr, id_len: int, dest: ptr, max_len: int): int = "mac#bats_js_read_input_value"
+end
 
 implement measure{li}{ni}(node_id, id_len) = let
   val r = _bats_js_measure_node(
-    $UNSAFE.castvwtp1{ptr}(node_id), id_len)
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(node_id) end, id_len)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
 end
 
-implement get_measure_x() = $extfcall(int, "bats_bridge_measure_get", 0)
-implement get_measure_y() = $extfcall(int, "bats_bridge_measure_get", 1)
-implement get_measure_w() = $extfcall(int, "bats_bridge_measure_get", 2)
-implement get_measure_h() = $extfcall(int, "bats_bridge_measure_get", 3)
-implement get_measure_scroll_w() = $extfcall(int, "bats_bridge_measure_get", 4)
-implement get_measure_scroll_h() = $extfcall(int, "bats_bridge_measure_get", 5)
+implement get_measure_x() = $UNSAFE begin $extfcall(int, "bats_bridge_measure_get", 0) end
+implement get_measure_y() = $UNSAFE begin $extfcall(int, "bats_bridge_measure_get", 1) end
+implement get_measure_w() = $UNSAFE begin $extfcall(int, "bats_bridge_measure_get", 2) end
+implement get_measure_h() = $UNSAFE begin $extfcall(int, "bats_bridge_measure_get", 3) end
+implement get_measure_scroll_w() = $UNSAFE begin $extfcall(int, "bats_bridge_measure_get", 4) end
+implement get_measure_scroll_h() = $UNSAFE begin $extfcall(int, "bats_bridge_measure_get", 5) end
 
 implement query_selector{lb}{n}(sel, sel_len) = let
   val r = _bats_js_query_selector(
-    $UNSAFE.castvwtp1{ptr}(sel),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(sel) end,
     sel_len)
 in
   if r >= 0 then $R.some(r) else $R.none()
@@ -112,14 +114,14 @@ implement caret_position_from_point(x, y) =
 
 implement read_text_content{li}{ni}(node_id, id_len) =
   _bats_js_read_text_content(
-    $UNSAFE.castvwtp1{ptr}(node_id), id_len)
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(node_id) end, id_len)
 
 implement read_text_content_get{n}(len) =
   stash_read(stash_get_int(1), len)
 
 implement measure_text_offset{li}{ni}(node_id, id_len, offset) =
   _bats_js_measure_text_offset(
-    $UNSAFE.castvwtp1{ptr}(node_id), id_len, offset)
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(node_id) end, id_len, offset)
 
 implement get_selection_text() =
   _bats_js_get_selection_text()
@@ -133,12 +135,8 @@ implement get_selection_rect() =
 implement get_selection_range() =
   _bats_js_get_selection_range()
 
-extern fun _bats_js_read_input_value
-  (id: ptr, id_len: int, dest: ptr, max_len: int): int = "mac#bats_js_read_input_value"
-
 implement read_input_value{li}{ni}(node_id, id_len, max_len) =
   _bats_js_read_input_value(
-    $UNSAFE.castvwtp1{ptr}(node_id), id_len, the_null_ptr, max_len)
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(node_id) end, id_len, the_null_ptr, max_len)
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/event.bats
+++ b/src/event.bats
@@ -39,7 +39,6 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_add_event_listener
   (id: ptr, id_len: int, event_type: ptr, type_len: int, listener_id: int)
   : void = "mac#bats_js_add_event_listener"
@@ -50,43 +49,43 @@ extern fun _bats_js_remove_event_listener
   (listener_id: int): void = "mac#bats_js_remove_event_listener"
 extern fun _bats_js_prevent_default
   (): void = "mac#bats_js_prevent_default"
+end
 
 implement listen{li}{ni}{lb}{n}
   (node_id, id_len, event_type, type_len, listener_id, callback) = let
-  val cbp = $UNSAFE.castvwtp0{ptr}(callback)
-  val () = $extfcall(void, "bats_listener_set", listener_id, cbp)
+  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(callback) end
+  val () = $UNSAFE begin $extfcall(void, "bats_listener_set", listener_id, cbp) end
 in _bats_js_add_event_listener(
-    $UNSAFE.castvwtp1{ptr}(node_id), id_len,
-    $UNSAFE.castvwtp1{ptr}(event_type),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(node_id) end, id_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(event_type) end,
     type_len, listener_id) end
 
 implement listen_document{lb}{n}
   (event_type, type_len, listener_id, callback) = let
-  val cbp = $UNSAFE.castvwtp0{ptr}(callback)
-  val () = $extfcall(void, "bats_listener_set", listener_id, cbp)
+  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(callback) end
+  val () = $UNSAFE begin $extfcall(void, "bats_listener_set", listener_id, cbp) end
 in _bats_js_add_document_listener(
-    $UNSAFE.castvwtp1{ptr}(event_type),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(event_type) end,
     type_len, listener_id) end
 
 implement unlisten(listener_id) = let
-  val () = $extfcall(void, "bats_listener_set", listener_id, the_null_ptr)
+  val () = $UNSAFE begin $extfcall(void, "bats_listener_set", listener_id, the_null_ptr) end
 in _bats_js_remove_event_listener(listener_id) end
 
 implement prevent_default() = _bats_js_prevent_default()
 
 implement get_payload{n}(len) = let
-  val sid = $extfcall(int, "bats_bridge_stash_get_int", 1)
+  val sid = $UNSAFE begin $extfcall(int, "bats_bridge_stash_get_int", 1) end
 in stash_read(sid, len) end
 
 implement on_event(listener_id, payload_len) = let
-  val cbp = $extfcall(ptr, "bats_listener_get", listener_id)
+  val cbp = $UNSAFE begin $extfcall(ptr, "bats_listener_get", listener_id) end
 in
   if ptr_isnot_null(cbp) then let
-    val cb = $UNSAFE.cast{(int) -<cloref1> int}(cbp)
+    val cb = $UNSAFE begin $UNSAFE.cast{(int) -<cloref1> int}(cbp) end
     val _ = cb(payload_len)
   in () end
   else ()
 end
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/fetch.bats
+++ b/src/fetch.bats
@@ -30,15 +30,15 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_fetch
   (url: ptr, url_len: int, resolver_id: int): void = "mac#bats_js_fetch"
+end
 
 implement fetch{lb}{n}(url, url_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_fetch(
-    $UNSAFE.castvwtp1{ptr}(url), url_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end, url_len,
     id)
 in p end
 
@@ -52,5 +52,4 @@ implement on_fetch_complete(resolver_id, status, body_len) = let
   val () = stash_set_int(0, body_len)
 in $P.fire(resolver_id, status) end
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/file.bats
+++ b/src/file.bats
@@ -41,19 +41,19 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_file_open
   (id: ptr, id_len: int, resolver_id: int): void = "mac#bats_js_file_open"
 extern fun _bats_js_file_read
   (handle: int, file_offset: int, len: int, out: ptr): int = "mac#bats_js_file_read"
 extern fun _bats_js_file_close
   (handle: int): void = "mac#bats_js_file_close"
+end
 
 implement file_open{li}{ni}(input_node_id, id_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_file_open(
-    $UNSAFE.castvwtp1{ptr}(input_node_id), id_len, id)
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(input_node_id) end, id_len, id)
 in p end
 
 implement file_size() = stash_get_int(0)
@@ -65,7 +65,7 @@ implement file_name{n}(len) =
 
 implement file_read{l}{n}(handle, file_offset, out, len) = let
   val r = _bats_js_file_read(handle, file_offset, len,
-    $UNSAFE.castvwtp1{ptr}(out))
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
 end
@@ -76,5 +76,4 @@ implement on_file_open(resolver_id, handle, size) = let
   val () = stash_set_int(0, size)
 in $P.fire(resolver_id, handle) end
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/idb.bats
+++ b/src/idb.bats
@@ -52,7 +52,6 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_idb_js_put
   (key: ptr, key_len: int, val_data: ptr, val_len: int, resolver_id: int)
   : void = "mac#bats_idb_js_put"
@@ -65,13 +64,16 @@ extern fun _bats_idb_js_delete
 extern fun _bats_idb_js_list_keys
   (prefix: ptr, prefix_len: int, resolver_id: int)
   : void = "mac#bats_idb_js_list_keys"
+extern fun _bats_js_idb_delete_database
+  (): void = "mac#bats_js_idb_delete_database"
+end
 
 implement idb_put{lk}{nk}{lv}{nv}(key, key_len, val_data, val_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_put(
-    $UNSAFE.castvwtp1{ptr}(key), key_len,
-    $UNSAFE.castvwtp1{ptr}(val_data), val_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(key) end, key_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(val_data) end, val_len,
     id)
 in p end
 
@@ -79,7 +81,7 @@ implement idb_get{lk}{nk}(key, key_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_get(
-    $UNSAFE.castvwtp1{ptr}(key), key_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(key) end, key_len,
     id)
 in p end
 
@@ -90,7 +92,7 @@ implement idb_delete{lk}{nk}(key, key_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_delete(
-    $UNSAFE.castvwtp1{ptr}(key), key_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(key) end, key_len,
     id)
 in p end
 
@@ -98,7 +100,7 @@ implement idb_list_keys{lb}{n}(prefix, prefix_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_idb_js_list_keys(
-    $UNSAFE.castvwtp1{ptr}(prefix), prefix_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(prefix) end, prefix_len,
     id)
 in p end
 
@@ -111,10 +113,6 @@ implement on_idb_fire(resolver_id, status) =
 implement on_idb_fire_get(resolver_id, data_len) =
   $P.fire(resolver_id, data_len)
 
-extern fun _bats_js_idb_delete_database
-  (): void = "mac#bats_js_idb_delete_database"
-
 implement idb_delete_database() = _bats_js_idb_delete_database()
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/media.bats
+++ b/src/media.bats
@@ -26,33 +26,32 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_match_media
   (query: ptr, query_len: int): int = "mac#bats_js_match_media"
 extern fun _bats_js_listen_media
   (query: ptr, query_len: int, listener_id: int)
   : void = "mac#bats_js_listen_media"
+end
 
 implement match_media{lb}{n}(query, query_len) =
   _bats_js_match_media(
-    $UNSAFE.castvwtp1{ptr}(query), query_len)
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(query) end, query_len)
 
 implement listen_media{lb}{n}(query, query_len, listener_id, callback) = let
-  val cbp = $UNSAFE.castvwtp0{ptr}(callback)
-  val () = $extfcall(void, "bats_listener_set", listener_id, cbp)
+  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(callback) end
+  val () = $UNSAFE begin $extfcall(void, "bats_listener_set", listener_id, cbp) end
 in _bats_js_listen_media(
-    $UNSAFE.castvwtp1{ptr}(query), query_len,
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(query) end, query_len,
     listener_id) end
 
 implement on_media_change(listener_id, matches) = let
-  val cbp = $extfcall(ptr, "bats_listener_get", listener_id)
+  val cbp = $UNSAFE begin $extfcall(ptr, "bats_listener_get", listener_id) end
 in
   if ptr_isnot_null(cbp) then let
-    val cb = $UNSAFE.cast{(int) -<cloref1> int}(cbp)
+    val cb = $UNSAFE begin $UNSAFE.cast{(int) -<cloref1> int}(cbp) end
     val _ = cb(matches)
   in () end
   else ()
 end
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/nav.bats
+++ b/src/nav.bats
@@ -43,7 +43,6 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_get_url
   (out: ptr, max_len: int): int = "mac#bats_js_get_url"
 extern fun _bats_js_get_url_hash
@@ -54,10 +53,13 @@ extern fun _bats_js_replace_state
   (url: ptr, url_len: int): void = "mac#bats_js_replace_state"
 extern fun _bats_js_push_state
   (url: ptr, url_len: int): void = "mac#bats_js_push_state"
+extern fun _bats_js_reload
+  (): void = "mac#bats_js_reload"
+end
 
 implement get_url{l}{n}(out, max_len) = let
   val r = _bats_js_get_url(
-    $UNSAFE.castvwtp1{ptr}(out),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end,
     max_len)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
@@ -65,7 +67,7 @@ end
 
 implement get_hash{l}{n}(out, max_len) = let
   val r = _bats_js_get_url_hash(
-    $UNSAFE.castvwtp1{ptr}(out),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(out) end,
     max_len)
 in
   if r >= 0 then $R.ok(r) else $R.err(r)
@@ -73,37 +75,33 @@ end
 
 implement set_hash{lb}{n}(hash, hash_len) =
   _bats_js_set_url_hash(
-    $UNSAFE.castvwtp1{ptr}(hash),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(hash) end,
     hash_len)
 
 implement replace_state{lb}{n}(url, url_len) =
   _bats_js_replace_state(
-    $UNSAFE.castvwtp1{ptr}(url),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end,
     url_len)
 
 implement push_state{lb}{n}(url, url_len) =
   _bats_js_push_state(
-    $UNSAFE.castvwtp1{ptr}(url),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(url) end,
     url_len)
-
-extern fun _bats_js_reload
-  (): void = "mac#bats_js_reload"
 
 implement reload() = _bats_js_reload()
 
 implement set_popstate_callback(cb) = let
-  val cbp = $UNSAFE.castvwtp0{ptr}(cb)
-in $extfcall(void, "bats_listener_set", 999999, cbp) end
+  val cbp = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(cb) end
+in $UNSAFE begin $extfcall(void, "bats_listener_set", 999999, cbp) end end
 
 implement on_popstate(url_len) = let
-  val cbp = $extfcall(ptr, "bats_listener_get", 999999)
+  val cbp = $UNSAFE begin $extfcall(ptr, "bats_listener_get", 999999) end
 in
   if ptr_isnot_null(cbp) then let
-    val cb = $UNSAFE.cast{(int) -<cloref1> int}(cbp)
+    val cb = $UNSAFE begin $UNSAFE.cast{(int) -<cloref1> int}(cbp) end
     val _ = cb(url_len)
   in () end
   else ()
 end
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/notify.bats
+++ b/src/notify.bats
@@ -40,7 +40,6 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_notification_request_permission
   (resolver_id: int): void = "mac#bats_js_notification_request_permission"
 extern fun _bats_js_notification_show
@@ -50,6 +49,7 @@ extern fun _bats_js_push_subscribe
   : void = "mac#bats_js_push_subscribe"
 extern fun _bats_js_push_get_subscription
   (resolver_id: int): void = "mac#bats_js_push_get_subscription"
+end
 
 implement notify_request_permission() = let
   val @(p, r) = $P.create<int>()
@@ -59,14 +59,14 @@ in p end
 
 implement notify_show{lb}{n}(title, title_len) =
   _bats_js_notification_show(
-    $UNSAFE.castvwtp1{ptr}(title),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(title) end,
     title_len)
 
 implement notify_push_subscribe{lb}{n}(vapid, vapid_len) = let
   val @(p, r) = $P.create<int>()
   val id = $P.stash(r)
   val () = _bats_js_push_subscribe(
-    $UNSAFE.castvwtp1{ptr}(vapid),
+    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(vapid) end,
     vapid_len, id)
 in p end
 
@@ -85,5 +85,4 @@ implement on_permission_result(resolver_id, granted) =
 implement on_push_subscribe(resolver_id, json_len) =
   $P.fire(resolver_id, json_len)
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/stash.bats
+++ b/src/stash.bats
@@ -28,22 +28,24 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_js_stash_read
   (stash_id: int, dest: ptr, len: int): void = "mac#bats_js_stash_read"
+extern fun _bats_js_get_root_node
+  (): int = "mac#bats_js_get_root_node"
+end
 
 fun _bridge_recv{n:pos | n <= 1048576}
   (stash_id: int, len: int n): [l:agz] $A.arr(byte, l, n) = let
   val buf = $A.alloc<byte>(len)
-  val p = $UNSAFE.castvwtp1{ptr}(buf)
+  val p = $UNSAFE begin $UNSAFE.castvwtp1{ptr}(buf) end
   val () = _bats_js_stash_read(stash_id, p, len)
 in buf end
 
 fn _stash_get_int(slot: int): int =
-  $extfcall(int, "bats_bridge_stash_get_int", slot)
+  $UNSAFE begin $extfcall(int, "bats_bridge_stash_get_int", slot) end
 
 fn _stash_set_int(slot: int, v: int): void =
-  $extfcall(void, "bats_bridge_stash_set_int", slot, v)
+  $UNSAFE begin $extfcall(void, "bats_bridge_stash_set_int", slot, v) end
 
 implement stash_read{n}(stash_id, len) =
   _bridge_recv(stash_id, len)
@@ -52,10 +54,6 @@ implement stash_set_int(slot, v0) = _stash_set_int(slot, v0)
 
 implement stash_get_int(slot) = _stash_get_int(slot)
 
-extern fun _bats_js_get_root_node
-  (): int = "mac#bats_js_get_root_node"
-
 implement get_root_node() = _bats_js_get_root_node()
 
-end (* $UNSAFE *)
 end (* #target wasm *)

--- a/src/timer.bats
+++ b/src/timer.bats
@@ -24,13 +24,13 @@
 
 #target wasm begin
 $UNSAFE begin
-
 extern fun _bats_set_timer
   (delay_ms: int, resolver_id: int): void = "mac#bats_set_timer"
 extern fun _bats_get_time_ms
   (): int = "mac#bats_get_time_ms"
 extern fun _bats_exit
   (): void = "mac#bats_exit"
+end
 
 implement timer_set(delay_ms) = let
   val @(p, r) = $P.create<int>()
@@ -45,5 +45,4 @@ implement exit() = _bats_exit()
 implement on_timer_fire(resolver_id) =
   $P.fire(resolver_id, 0)
 
-end (* $UNSAFE *)
 end (* #target wasm *)


### PR DESCRIPTION
## Summary
- Closes the `$UNSAFE begin...end` block after extern fun declarations in 12 shared modules, instead of wrapping the entire implementation section
- Wraps individual `$UNSAFE.castvwtp1`, `$UNSAFE.castvwtp0`, `$UNSAFE.cast`, and `$extfcall` calls inside implement blocks with per-expression `$UNSAFE begin...end`
- Removes the trailing `end (* $UNSAFE *)` from each module since implements are now outside the unsafe block

Modules changed: clipboard, decompress, dom_read, event, fetch, file, idb, media, nav, notify, stash, timer.

Modules left unchanged (no let blocks inside $UNSAFE, no inner nesting issue): blob, dom, scroll, window, xml.

## Test plan
- [x] `bats check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)