### PR TITLE
Add explicit staload for js_emitter shared module

### DIFF
--- a/src/lib.bats
+++ b/src/lib.bats
@@ -10,6 +10,8 @@
 #use promise as P
 #use result as R
 
+staload "./js_emitter.bats"
+
 (* ============================================================
    C runtime -- stash, measure, listener tables + WASM exports
    ============================================================ *)


### PR DESCRIPTION
lib.bats calls emit_js_all from js_emitter.bats. Add explicit staload so it works as a dependency.