### PR TITLE
Convert viewtype-returning #pub fun to arrow syntax

### DIFF
--- a/src/blob.bats
+++ b/src/blob.bats
@@ -14,8 +14,8 @@
    mime: !$A.borrow(byte, lm, nm), mime_len: int nm): int
 
 #pub fun create_blob_url_get
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun revoke_blob_url
   {lb:agz}{n:pos}

--- a/src/clipboard.bats
+++ b/src/clipboard.bats
@@ -10,16 +10,15 @@
    ============================================================ *)
 
 #pub fun clipboard_write
-  {lb:agz}{n:nat}
-  (text: !$A.borrow(byte, lb, n), text_len: int n)
-  : $P.promise_pending(int)
+  : {lb:agz}{n:nat}
+  (!$A.borrow(byte, lb, n), int n) -> $P.promise_pending(int)
 
 #pub fun clipboard_read
-  (): $P.promise_pending(int)
+  : () -> $P.promise_pending(int)
 
 #pub fun clipboard_read_result
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun on_clipboard_complete
   (resolver_id: int, success: int): void = "ext#bats_on_clipboard_complete"

--- a/src/decompress.bats
+++ b/src/decompress.bats
@@ -11,9 +11,9 @@
    ============================================================ *)
 
 #pub fun decompress
-  {lb:agz}{n:pos}
-  (data: !$A.borrow(byte, lb, n), data_len: int n,
-   method: int): $P.promise_pending(int)
+  : {lb:agz}{n:pos}
+  (!$A.borrow(byte, lb, n), int n,
+   int) -> $P.promise_pending(int)
 
 #pub fun decompress_len(): int
 

--- a/src/dom_read.bats
+++ b/src/dom_read.bats
@@ -37,8 +37,8 @@
   (node_id: !$A.borrow(byte, li, ni), id_len: int ni): int
 
 #pub fun read_text_content_get
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun measure_text_offset
   {li:agz}{ni:pos}
@@ -48,8 +48,8 @@
 #pub fun get_selection_text(): int
 
 #pub fun get_selection_text_get
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun get_selection_rect(): void
 

--- a/src/event.bats
+++ b/src/event.bats
@@ -27,8 +27,8 @@
 #pub fun prevent_default(): void
 
 #pub fun get_payload
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun on_event
   (listener_id: int, payload_len: int): void = "ext#bats_on_event"

--- a/src/fetch.bats
+++ b/src/fetch.bats
@@ -10,15 +10,14 @@
    ============================================================ *)
 
 #pub fun fetch
-  {lb:agz}{n:pos}
-  (url: !$A.borrow(byte, lb, n), url_len: int n)
-  : $P.promise_pending(int)
+  : {lb:agz}{n:pos}
+  (!$A.borrow(byte, lb, n), int n) -> $P.promise_pending(int)
 
 #pub fun get_body_len(): int
 
 #pub fun get_body
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun on_fetch_complete
   (resolver_id: int, status: int, body_len: int)

--- a/src/file.bats
+++ b/src/file.bats
@@ -11,17 +11,16 @@
    ============================================================ *)
 
 #pub fun file_open
-  {li:agz}{ni:pos}
-  (input_node_id: !$A.borrow(byte, li, ni), id_len: int ni)
-  : $P.promise_pending(int)
+  : {li:agz}{ni:pos}
+  (!$A.borrow(byte, li, ni), int ni) -> $P.promise_pending(int)
 
 #pub fun file_size(): int
 
 #pub fun file_name_len(): int
 
 #pub fun file_name
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun file_read
   {l:agz}{n:pos}

--- a/src/idb.bats
+++ b/src/idb.bats
@@ -10,33 +10,29 @@
    ============================================================ *)
 
 #pub fun idb_put
-  {lk:agz}{nk:pos}{lv:agz}{nv:nat}
-  (key: !$A.borrow(byte, lk, nk), key_len: int nk,
-   val_data: !$A.borrow(byte, lv, nv), val_len: int nv)
-  : $P.promise_pending(int)
+  : {lk:agz}{nk:pos}{lv:agz}{nv:nat}
+  (!$A.borrow(byte, lk, nk), int nk,
+   !$A.borrow(byte, lv, nv), int nv) -> $P.promise_pending(int)
 
 #pub fun idb_get
-  {lk:agz}{nk:pos}
-  (key: !$A.borrow(byte, lk, nk), key_len: int nk)
-  : $P.promise_pending(int)
+  : {lk:agz}{nk:pos}
+  (!$A.borrow(byte, lk, nk), int nk) -> $P.promise_pending(int)
 
 #pub fun idb_get_result
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun idb_delete
-  {lk:agz}{nk:pos}
-  (key: !$A.borrow(byte, lk, nk), key_len: int nk)
-  : $P.promise_pending(int)
+  : {lk:agz}{nk:pos}
+  (!$A.borrow(byte, lk, nk), int nk) -> $P.promise_pending(int)
 
 #pub fun idb_list_keys
-  {lb:agz}{n:nat}
-  (prefix: !$A.borrow(byte, lb, n), prefix_len: int n)
-  : $P.promise_pending(int)
+  : {lb:agz}{n:nat}
+  (!$A.borrow(byte, lb, n), int n) -> $P.promise_pending(int)
 
 #pub fun idb_list_keys_result
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun idb_delete_database(): void
 

--- a/src/notify.bats
+++ b/src/notify.bats
@@ -10,23 +10,22 @@
    ============================================================ *)
 
 #pub fun notify_request_permission
-  (): $P.promise_pending(int)
+  : () -> $P.promise_pending(int)
 
 #pub fun notify_show
   {lb:agz}{n:pos}
   (title: !$A.borrow(byte, lb, n), title_len: int n): void
 
 #pub fun notify_push_subscribe
-  {lb:agz}{n:pos}
-  (vapid: !$A.borrow(byte, lb, n), vapid_len: int n)
-  : $P.promise_pending(int)
+  : {lb:agz}{n:pos}
+  (!$A.borrow(byte, lb, n), int n) -> $P.promise_pending(int)
 
 #pub fun notify_push_get_result
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun notify_push_get_subscription
-  (): $P.promise_pending(int)
+  : () -> $P.promise_pending(int)
 
 #pub fun on_permission_result
   (resolver_id: int, granted: int): void = "ext#bats_on_permission_result"

--- a/src/stash.bats
+++ b/src/stash.bats
@@ -9,8 +9,8 @@
    ============================================================ *)
 
 #pub fun stash_read
-  {n:pos | n <= 1048576}
-  (stash_id: int, len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int, int n) -> [l:agz] $A.arr(byte, l, n)
 
 #pub fun stash_set_int
   (slot: int, v: int): void

--- a/src/timer.bats
+++ b/src/timer.bats
@@ -9,7 +9,7 @@
    ============================================================ *)
 
 #pub fun timer_set
-  (delay_ms: int): $P.promise_pending(int)
+  : (int) -> $P.promise_pending(int)
 
 #pub fun get_time_ms(): int
 

--- a/src/xml.bats
+++ b/src/xml.bats
@@ -13,8 +13,8 @@
   (html: !$A.borrow(byte, lb, n), len: int n): int
 
 #pub fun xml_result
-  {n:pos | n <= 1048576}
-  (len: int n): [l:agz] $A.arr(byte, l, n)
+  : {n:pos | n <= 1048576}
+  (int n) -> [l:agz] $A.arr(byte, l, n)
 
 (* ============================================================
    WASM implementation


### PR DESCRIPTION
## Summary
- Convert `#pub fun` declarations returning viewtypes (`promise_pending`, `[l:agz] $A.arr`) from colon syntax to arrow syntax across 12 bridge source files
- Colon syntax on viewtype returns triggers an ATS2 patsopt parser bug; arrow syntax avoids it
- Only `#pub fun` declarations are changed; implement blocks are untouched

## Files changed
idb.bats, clipboard.bats, decompress.bats, fetch.bats, file.bats, notify.bats, timer.bats, blob.bats, dom_read.bats, event.bats, stash.bats, xml.bats

## Test plan
- [ ] `bats check` passes after republishing bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)