### PR TITLE
Add staload for cross-module stash references

### DIFF
--- a/src/blob.bats
+++ b/src/blob.bats
@@ -1,6 +1,7 @@
 (* blob -- blob URL creation, revocation, download for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 

--- a/src/clipboard.bats
+++ b/src/clipboard.bats
@@ -1,6 +1,7 @@
 (* clipboard -- clipboard read/write for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use promise as P

--- a/src/decompress.bats
+++ b/src/decompress.bats
@@ -1,6 +1,7 @@
 (* decompress -- decompression with blob cache for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use promise as P

--- a/src/dom_read.bats
+++ b/src/dom_read.bats
@@ -1,6 +1,7 @@
 (* dom_read -- DOM measurement, query, text content, selection for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use result as R

--- a/src/event.bats
+++ b/src/event.bats
@@ -1,6 +1,7 @@
 (* event -- DOM event listener management for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 

--- a/src/fetch.bats
+++ b/src/fetch.bats
@@ -1,6 +1,7 @@
 (* fetch -- network fetch with promise-based async for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use promise as P

--- a/src/file.bats
+++ b/src/file.bats
@@ -1,6 +1,7 @@
 (* file -- file input/read/close for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use promise as P

--- a/src/idb.bats
+++ b/src/idb.bats
@@ -1,6 +1,7 @@
 (* idb -- IndexedDB key-value storage for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use promise as P

--- a/src/notify.bats
+++ b/src/notify.bats
@@ -1,6 +1,7 @@
 (* notify -- notifications and push subscriptions for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 #use promise as P

--- a/src/xml.bats
+++ b/src/xml.bats
@@ -1,6 +1,7 @@
 (* xml -- HTML/XML parsing for bridge *)
 
 #include "share/atspre_staload.hats"
+staload "./stash.bats"
 
 #use array as A
 


### PR DESCRIPTION
Modules using stash functions need explicit staload ./stash.bats.