### PR TITLE
Add C forward declarations for WASM bridge functions

### DIFF
--- a/src/dom_read.bats
+++ b/src/dom_read.bats
@@ -68,6 +68,9 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern int bats_bridge_measure_get(int slot);
+%}
 extern fun _bats_js_measure_node
   (id: ptr, id_len: int): int = "mac#bats_js_measure_node"
 extern fun _bats_js_query_selector

--- a/src/event.bats
+++ b/src/event.bats
@@ -40,6 +40,11 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_listener_set(int id, void *cb);
+extern void *bats_listener_get(int id);
+extern int bats_bridge_stash_get_int(int slot);
+%}
 extern fun _bats_js_add_event_listener
   (id: ptr, id_len: int, event_type: ptr, type_len: int, listener_id: int)
   : void = "mac#bats_js_add_event_listener"

--- a/src/lib.bats
+++ b/src/lib.bats
@@ -18,9 +18,7 @@ staload "./js_emitter.bats"
 
 #target wasm begin
 $UNSAFE begin
-%{#
-#ifndef _BRIDGE_RUNTIME_DEFINED
-#define _BRIDGE_RUNTIME_DEFINED
+%{$
 /* Bridge int stash -- 4 slots for stash IDs and metadata */
 static int _bridge_stash_int[4] = {0};
 
@@ -55,7 +53,6 @@ void *bats_listener_get(int id) {
   if (id >= 0 && id < _BRIDGE_MAX_LISTENERS) return _bridge_listener_table[id];
   return (void*)0;
 }
-#endif
 %}
 end
 end (* #target wasm *)

--- a/src/media.bats
+++ b/src/media.bats
@@ -26,6 +26,10 @@
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_listener_set(int id, void *cb);
+extern void *bats_listener_get(int id);
+%}
 extern fun _bats_js_match_media
   (query: ptr, query_len: int): int = "mac#bats_js_match_media"
 extern fun _bats_js_listen_media

--- a/src/nav.bats
+++ b/src/nav.bats
@@ -43,6 +43,10 @@
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_listener_set(int id, void *cb);
+extern void *bats_listener_get(int id);
+%}
 extern fun _bats_js_get_url
   (out: ptr, max_len: int): int = "mac#bats_js_get_url"
 extern fun _bats_js_get_url_hash

--- a/src/stash.bats
+++ b/src/stash.bats
@@ -28,6 +28,10 @@
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern int bats_bridge_stash_get_int(int slot);
+extern void bats_bridge_stash_set_int(int slot, int v);
+%}
 extern fun _bats_js_stash_read
   (stash_id: int, dest: ptr, len: int): void = "mac#bats_js_stash_read"
 extern fun _bats_js_get_root_node


### PR DESCRIPTION
## Summary
- Change `%{#` to `%{$` (late-load) in lib.bats to prevent patsopt from inlining C definitions into dependent compilation units
- Remove `#ifndef _BRIDGE_RUNTIME_DEFINED` guard (compiler no longer passes the flag)
- Add `%{` forward declarations in event.bats, stash.bats, nav.bats, media.bats, and dom_read.bats for bridge functions called via `$extfcall`

## Test plan
- [x] PWA example builds with these changes
- [x] WASM binary has all 20 required exports
- [x] Playwright smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)