### PR TITLE
Re-export sub-module APIs from lib.bats

### DIFF
--- a/src/lib.bats
+++ b/src/lib.bats
@@ -11,6 +11,23 @@
 #use result as R
 
 staload "./js_emitter.bats"
+staload "./stash.bats"
+staload "./decompress.bats"
+staload "./event.bats"
+staload "./file.bats"
+staload "./blob.bats"
+staload "./clipboard.bats"
+staload "./dom.bats"
+staload "./dom_read.bats"
+staload "./fetch.bats"
+staload "./idb.bats"
+staload "./media.bats"
+staload "./nav.bats"
+staload "./notify.bats"
+staload "./scroll.bats"
+staload "./timer.bats"
+staload "./window.bats"
+staload "./xml.bats"
 
 (* ============================================================
    C runtime -- stash, measure, listener tables + WASM exports


### PR DESCRIPTION
## Summary
- Add `staload` for all sub-modules (stash, decompress, event, file, blob, etc.) in lib.bats
- This makes functions from sub-modules accessible via `$B.name` when consumers `#use bridge as B`
- Previously, only lib.bats functions were accessible; sub-module functions required separate staload

## Test plan
- [x] `bats check` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)