### PR TITLE
Add C forward declarations for JS FFI imports

### DIFF
--- a/src/blob.bats
+++ b/src/blob.bats
@@ -34,7 +34,11 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
-
+%{
+extern int bats_js_create_blob_url(void*, int, void*, int);
+extern void bats_js_revoke_blob_url(void*, int);
+extern void bats_js_download_blob(void*, int, void*, int, void*, int);
+%}
 extern fun _bats_js_create_blob_url
   (data: ptr, data_len: int, mime: ptr, mime_len: int): int
   = "mac#bats_js_create_blob_url"

--- a/src/clipboard.bats
+++ b/src/clipboard.bats
@@ -33,6 +33,10 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_js_clipboard_write_text(void*, int, int);
+extern void bats_js_clipboard_read_text(int);
+%}
 extern fun _bats_js_clipboard_write_text
   (text: ptr, text_len: int, resolver_id: int)
   : void = "mac#bats_js_clipboard_write_text"

--- a/src/decompress.bats
+++ b/src/decompress.bats
@@ -36,6 +36,11 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_js_decompress(void*, int, int, int);
+extern int bats_js_blob_read(int, int, int, void*);
+extern void bats_js_blob_free(int);
+%}
 extern fun _bats_js_decompress
   (data: ptr, data_len: int, method: int, resolver_id: int)
   : void = "mac#bats_js_decompress"

--- a/src/dom.bats
+++ b/src/dom.bats
@@ -28,7 +28,11 @@
 
 #target wasm begin
 $UNSAFE begin
-
+%{
+extern void bats_dom_flush(void*, int);
+extern void bats_js_set_image_src(void*, int, void*, int, void*, int);
+extern void bats_js_click_node(void*, int);
+%}
 extern fun _bats_dom_flush
   (buf: ptr, len: int): void = "mac#bats_dom_flush"
 extern fun _bats_js_set_image_src

--- a/src/dom_read.bats
+++ b/src/dom_read.bats
@@ -70,6 +70,15 @@ staload "./stash.bats"
 $UNSAFE begin
 %{
 extern int bats_bridge_measure_get(int slot);
+extern int bats_js_measure_node(void*, int);
+extern int bats_js_query_selector(void*, int);
+extern int bats_js_caret_position_from_point(int, int);
+extern int bats_js_read_text_content(void*, int);
+extern int bats_js_measure_text_offset(void*, int, int);
+extern int bats_js_get_selection_text(void);
+extern void bats_js_get_selection_rect(void);
+extern void bats_js_get_selection_range(void);
+extern int bats_js_read_input_value(void*, int, void*, int);
 %}
 extern fun _bats_js_measure_node
   (id: ptr, id_len: int): int = "mac#bats_js_measure_node"

--- a/src/event.bats
+++ b/src/event.bats
@@ -44,6 +44,10 @@ $UNSAFE begin
 extern void bats_listener_set(int id, void *cb);
 extern void *bats_listener_get(int id);
 extern int bats_bridge_stash_get_int(int slot);
+extern void bats_js_add_event_listener(void*, int, void*, int, int);
+extern void bats_js_add_document_listener(void*, int, int);
+extern void bats_js_remove_event_listener(int);
+extern void bats_js_prevent_default(void);
 %}
 extern fun _bats_js_add_event_listener
   (id: ptr, id_len: int, event_type: ptr, type_len: int, listener_id: int)

--- a/src/fetch.bats
+++ b/src/fetch.bats
@@ -30,6 +30,9 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_js_fetch(void*, int, int);
+%}
 extern fun _bats_js_fetch
   (url: ptr, url_len: int, resolver_id: int): void = "mac#bats_js_fetch"
 end

--- a/src/file.bats
+++ b/src/file.bats
@@ -41,6 +41,11 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_js_file_open(void*, int, int);
+extern int bats_js_file_read(int, int, int, void*);
+extern void bats_js_file_close(int);
+%}
 extern fun _bats_js_file_open
   (id: ptr, id_len: int, resolver_id: int): void = "mac#bats_js_file_open"
 extern fun _bats_js_file_read

--- a/src/idb.bats
+++ b/src/idb.bats
@@ -49,6 +49,13 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_idb_js_put(void*, int, void*, int, int);
+extern void bats_idb_js_get(void*, int, int);
+extern void bats_idb_js_delete(void*, int, int);
+extern void bats_idb_js_list_keys(void*, int, int);
+extern void bats_js_idb_delete_database(void);
+%}
 extern fun _bats_idb_js_put
   (key: ptr, key_len: int, val_data: ptr, val_len: int, resolver_id: int)
   : void = "mac#bats_idb_js_put"

--- a/src/media.bats
+++ b/src/media.bats
@@ -29,6 +29,8 @@ $UNSAFE begin
 %{
 extern void bats_listener_set(int id, void *cb);
 extern void *bats_listener_get(int id);
+extern int bats_js_match_media(void*, int);
+extern void bats_js_listen_media(void*, int, int);
 %}
 extern fun _bats_js_match_media
   (query: ptr, query_len: int): int = "mac#bats_js_match_media"

--- a/src/nav.bats
+++ b/src/nav.bats
@@ -46,6 +46,12 @@ $UNSAFE begin
 %{
 extern void bats_listener_set(int id, void *cb);
 extern void *bats_listener_get(int id);
+extern int bats_js_get_url(void*, int);
+extern int bats_js_get_url_hash(void*, int);
+extern void bats_js_set_url_hash(void*, int);
+extern void bats_js_replace_state(void*, int);
+extern void bats_js_push_state(void*, int);
+extern void bats_js_reload(void);
 %}
 extern fun _bats_js_get_url
   (out: ptr, max_len: int): int = "mac#bats_js_get_url"

--- a/src/notify.bats
+++ b/src/notify.bats
@@ -40,6 +40,12 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_js_notification_request_permission(int);
+extern void bats_js_notification_show(void*, int);
+extern void bats_js_push_subscribe(void*, int, int);
+extern void bats_js_push_get_subscription(int);
+%}
 extern fun _bats_js_notification_request_permission
   (resolver_id: int): void = "mac#bats_js_notification_request_permission"
 extern fun _bats_js_notification_show

--- a/src/scroll.bats
+++ b/src/scroll.bats
@@ -34,7 +34,12 @@
 
 #target wasm begin
 $UNSAFE begin
-
+%{
+extern void bats_js_scroll_to(void*, int, int, int);
+extern void bats_js_scroll_into_view(void*, int, int);
+extern void bats_js_set_scroll_top(void*, int, int);
+extern void bats_js_set_scroll_left(void*, int, int);
+%}
 extern fun _bats_js_scroll_to
   (id: ptr, id_len: int, x: int, y: int): void = "mac#bats_js_scroll_to"
 extern fun _bats_js_scroll_into_view

--- a/src/stash.bats
+++ b/src/stash.bats
@@ -31,6 +31,8 @@ $UNSAFE begin
 %{
 extern int bats_bridge_stash_get_int(int slot);
 extern void bats_bridge_stash_set_int(int slot, int v);
+extern void bats_js_stash_read(int, void*, int);
+extern int bats_js_get_root_node(void);
 %}
 extern fun _bats_js_stash_read
   (stash_id: int, dest: ptr, len: int): void = "mac#bats_js_stash_read"

--- a/src/timer.bats
+++ b/src/timer.bats
@@ -24,6 +24,11 @@
 
 #target wasm begin
 $UNSAFE begin
+%{
+extern void bats_set_timer(int, int);
+extern int bats_get_time_ms(void);
+extern void bats_exit(void);
+%}
 extern fun _bats_set_timer
   (delay_ms: int, resolver_id: int): void = "mac#bats_set_timer"
 extern fun _bats_get_time_ms

--- a/src/window.bats
+++ b/src/window.bats
@@ -22,7 +22,11 @@
 
 #target wasm begin
 $UNSAFE begin
-
+%{
+extern void bats_js_focus_window(void);
+extern int bats_js_get_visibility_state(void);
+extern void bats_js_log(int, void*, int);
+%}
 extern fun _bats_js_focus_window
   (): void = "mac#bats_js_focus_window"
 extern fun _bats_js_get_visibility_state

--- a/src/xml.bats
+++ b/src/xml.bats
@@ -23,7 +23,9 @@ staload "./stash.bats"
 
 #target wasm begin
 $UNSAFE begin
-
+%{
+extern int bats_js_parse_html(void*, int);
+%}
 extern fun _bats_js_parse_html
   (html: ptr, len: int): int = "mac#bats_js_parse_html"
 


### PR DESCRIPTION
## Summary
- Adds `%{}` blocks with C `extern` forward declarations for all `mac#` JS FFI functions across 17 bridge modules
- Eliminates ~58 implicit function declaration errors from clang during WASM builds
- No behavioral change — the functions are WASM imports resolved by wasm-ld

Fixes #32

## Test plan
- [x] `bats check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)