### PR TITLE
Add linear resource stash functions

### DIFF
--- a/src/stash.bats
+++ b/src/stash.bats
@@ -22,6 +22,17 @@
    Read the string with stash_read(stash_get_int(1), len). *)
 #pub fun get_root_node(): int
 
+(* Linear resource stash: store/retrieve viewtype values by slot.
+   Consumes the value on stash, produces it on unstash.
+   The caller must unstash with the same type that was stashed. *)
+#pub fun{a:vt@ype}
+stash_linear
+  (slot: int, x: a): void
+
+#pub fun{a:vt@ype}
+unstash_linear
+  (slot: int): a
+
 (* ============================================================
    WASM implementation
    ============================================================ *)
@@ -33,11 +44,27 @@ extern int bats_bridge_stash_get_int(int slot);
 extern void bats_bridge_stash_set_int(int slot, int v);
 extern void bats_js_stash_read(int, void*, int);
 extern int bats_js_get_root_node(void);
+
+#ifndef _BATS_STASH_PTR_DEFINED
+#define _BATS_STASH_PTR_DEFINED
+#define _BATS_STASH_PTR_SLOTS 8
+static void* _bats_stash_ptrs[_BATS_STASH_PTR_SLOTS];
+static void _bats_stash_set_ptr(int slot, void* p) {
+  if (slot >= 0 && slot < _BATS_STASH_PTR_SLOTS) _bats_stash_ptrs[slot] = p;
+}
+static void* _bats_stash_get_ptr(int slot) {
+  return (slot >= 0 && slot < _BATS_STASH_PTR_SLOTS) ? _bats_stash_ptrs[slot] : (void*)0;
+}
+#endif
 %}
 extern fun _bats_js_stash_read
   (stash_id: int, dest: ptr, len: int): void = "mac#bats_js_stash_read"
 extern fun _bats_js_get_root_node
   (): int = "mac#bats_js_get_root_node"
+extern fun _bats_stash_set_ptr
+  (slot: int, p: ptr): void = "mac#_bats_stash_set_ptr"
+extern fun _bats_stash_get_ptr
+  (slot: int): ptr = "mac#_bats_stash_get_ptr"
 end
 
 fun _bridge_recv{n:pos | n <= 1048576}
@@ -61,5 +88,15 @@ implement stash_set_int(slot, v0) = _stash_set_int(slot, v0)
 implement stash_get_int(slot) = _stash_get_int(slot)
 
 implement get_root_node() = _bats_js_get_root_node()
+
+implement{a}
+stash_linear(slot, x) = let
+  val p = $UNSAFE begin $UNSAFE.castvwtp0{ptr}(x) end
+in _bats_stash_set_ptr(slot, p) end
+
+implement{a}
+unstash_linear(slot) = let
+  val p = _bats_stash_get_ptr(slot)
+in $UNSAFE begin $UNSAFE.castvwtp0{a}(p) end end
 
 end (* #target wasm *)


### PR DESCRIPTION
## Summary
- Add `stash_linear{a:vt@ype}` and `unstash_linear{a:vt@ype}` template functions for slot-indexed storage of linear viewtype values
- Add C backing store with 8 pointer slots
- Unsafe conversions contained within bridge, enabling safe packages (like dom) to stash/retrieve linear resources

## Test plan
- [x] `bats check` passes for bridge
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)