### PR TITLE
Remove conflicting ATS_MALLOC extern declaration

### DIFF
--- a/src/stash.bats
+++ b/src/stash.bats
@@ -53,7 +53,6 @@ extern int bats_js_get_root_node(void);
 
 #ifndef _BATS_BYTES_TO_STRING_DEFINED
 #define _BATS_BYTES_TO_STRING_DEFINED
-extern void* ATS_MALLOC(int);
 static char* _bats_borrow_to_string(void* base, int off, int len, int max) {
   char* s;
   int i;


### PR DESCRIPTION
## Summary
- Remove explicit `extern void* ATS_MALLOC(int)` declaration from borrow_to_string C code
- ATS_MALLOC is already a macro from ATS2 runtime; the extern conflicted with `atsruntime_malloc_undef`'s `size_t` parameter type

## Test plan
- [x] `bats check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)