### PR TITLE
Revert g1 return types from stash/file/decompress

### DIFF
--- a/src/decompress.bats
+++ b/src/decompress.bats
@@ -16,7 +16,7 @@ staload "./stash.bats"
   (data: !$A.borrow(byte, lb, n), data_len: int n,
    method: int, resolver_id: int): void
 
-#pub fun decompress_len(): [n:int] int n
+#pub fun decompress_len(): int
 
 #pub fun blob_read
   {l:agz}{n:pos}

--- a/src/file.bats
+++ b/src/file.bats
@@ -15,7 +15,7 @@ staload "./stash.bats"
   : {li:agz}{ni:pos}
   (!$A.borrow(byte, li, ni), int ni) -> $P.promise_pending(int)
 
-#pub fun file_size(): [n:int] int n
+#pub fun file_size(): int
 
 #pub fun file_name_len(): int
 

--- a/src/stash.bats
+++ b/src/stash.bats
@@ -18,7 +18,7 @@
 
 #pub fun stash_get_int
   {s:nat | s < 32}
-  (slot: int s): [n:int] int n
+  (slot: int s): int
 
 (* Get root element's HTML id as stashed string. Returns byte length.
    Read the string with stash_read(stash_get_int(1), len). *)
@@ -89,7 +89,7 @@ implement stash_read{n}(stash_id, len) =
 
 implement stash_set_int{s}(slot, v0) = _stash_set_int(slot, v0)
 
-implement stash_get_int{s}(slot) = g1ofg0_int(_stash_get_int(slot))
+implement stash_get_int{s}(slot) = _stash_get_int(slot)
 
 implement get_root_node() = _bats_js_get_root_node()
 


### PR DESCRIPTION
Reverts PR #55. g1 returns cause WASM runtime crashes in downstream consumers.